### PR TITLE
Separating JS into its own file and including gulp build process to combine and minfy all js files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 vendor
 _vendor/
 app/bootstrap.php.cache
+node_modules

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,18 @@
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+var concat = require('gulp-concat');
+var uglify = require('gulp-uglify');
+var sourcemaps = require('gulp-sourcemaps');
+
+gulp.task('default', ['scripts']);
+
+// Concatenate & Minify JS
+gulp.task('scripts', function() {
+    return gulp.src('web/js/*.js')
+        .pipe(sourcemaps.init())
+        	.pipe(concat('combined.js'))
+        	//only uglify if gulp is ran with '--type prod'
+        	.pipe(gutil.env.type === 'prod' ? uglify() : gutil.noop())
+        .pipe(sourcemaps.write())
+        .pipe(gulp.dest('web/js'));
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "purl",
+  "version": "1.0.0",
+  "description": "Purl (Petite URL) is an open source project with the goal of providing you with your own private URL shortener!",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/veloxy/purl.git"
+  },
+  "keywords": [
+    "symfony",
+    "url-shortenr",
+    "php"
+  ],
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/veloxy/purl/issues"
+  },
+  "homepage": "https://github.com/veloxy/purl#readme",
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-concat": "^2.6.0",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-uglify": "^2.0.0"
+  }
+}

--- a/src/AppBundle/Resources/views/layout.html.twig
+++ b/src/AppBundle/Resources/views/layout.html.twig
@@ -67,8 +67,7 @@
     </div>
     
     {% block javascripts %}
-    <script src="{{ asset('js/clipboard.min.js') }}"></script>
-    <script src="{{ asset('js/layout.js') }}"></script>
+    <script src="{{ asset('js/combined.js') }}"></script>
     {%endblock%}
 
 </body>

--- a/src/AppBundle/Resources/views/layout.html.twig
+++ b/src/AppBundle/Resources/views/layout.html.twig
@@ -65,9 +65,11 @@
     <div class="container">
         {% block body %}{% endblock %}
     </div>
+    
+    {% block javascripts %}
     <script src="{{ asset('js/clipboard.min.js') }}"></script>
-    <script type="application/javascript">
-        new Clipboard('.btn');
-    </script>
+    <script src="{{ asset('js/layout.js') }}"></script>
+    {%endblock%}
+
 </body>
 </html>

--- a/web/js/layout.js
+++ b/web/js/layout.js
@@ -1,0 +1,1 @@
+new Clipboard('.btn');


### PR DESCRIPTION
This pull request is to resolve #4 

I created an external js file to hold the inline js logic from the layout.html.twig file. Seems like a small amount of code to externalize, but it could easily expand in the future. I then added  gulp build task to minify and concatenate all js files located in the web/js folder. To minify simply run grunt type=prod from the root folder, else running grunt along will not minify, but concatenate the files. This way you can view the readable version of the js files without a problem.
